### PR TITLE
Adds tests for lighting without specifying normals.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ SRCS = \
 	$(CURDIR)/tests/depth_format_tests.cpp \
 	$(CURDIR)/tests/front_face_tests.cpp \
 	$(CURDIR)/tests/image_blit_tests.cpp \
+	$(CURDIR)/tests/lighting_normal_tests.cpp \
 	$(CURDIR)/tests/material_alpha_tests.cpp \
 	$(CURDIR)/tests/test_suite.cpp \
 	$(CURDIR)/tests/texture_format_tests.cpp \

--- a/main.cpp
+++ b/main.cpp
@@ -19,6 +19,7 @@
 #include "tests/depth_format_tests.h"
 #include "tests/front_face_tests.h"
 #include "tests/image_blit_tests.h"
+#include "tests/lighting_normal_tests.h"
 #include "tests/material_alpha_tests.h"
 #include "tests/texture_format_tests.h"
 #include "tests/two_d_line_tests.h"
@@ -89,6 +90,10 @@ int main() {
 }
 
 static void register_suites(TestHost &host, std::vector<std::shared_ptr<TestSuite>> &test_suites) {
+  {
+    auto suite = std::make_shared<LightingNormalTests>(host, kOutputDirectory);
+    test_suites.push_back(std::dynamic_pointer_cast<TestSuite>(suite));
+  }
   {
     auto suite = std::make_shared<MaterialAlphaTests>(host, kOutputDirectory);
     test_suites.push_back(std::dynamic_pointer_cast<TestSuite>(suite));

--- a/nxdk_ext.h
+++ b/nxdk_ext.h
@@ -118,4 +118,9 @@
 #define NV05C_SET_COLOR_FORMAT_LE_X17R5G5B5 0x00000002
 #define NV05C_SET_COLOR_FORMAT_LE_X8R8G8B8 0x00000003
 
+// This is sent whenever a vertex buffer is drawn after being locked.
+// Failing to send it in a tight modification loop will cause the hardware to re-use previously set data even if new
+// values are set (likely it skips fetching the updated memory from system RAM).
+#define NV097_BREAK_VERTEX_BUFFER_CACHE 0x1710
+
 #endif  // NXDK_ZBUFFER_TESTS_NXDK_MISSING_DEFINES_H

--- a/test_host.h
+++ b/test_host.h
@@ -54,6 +54,7 @@ class TestHost {
   uint32_t GetFramebufferHeight() const { return framebuffer_height_; }
 
   std::shared_ptr<VertexBuffer> AllocateVertexBuffer(uint32_t num_vertices);
+  void SetVertexBuffer(std::shared_ptr<VertexBuffer> buffer);
   std::shared_ptr<VertexBuffer> GetVertexBuffer() { return vertex_buffer_; }
 
   void Clear(uint32_t argb = 0xFF000000, uint32_t depth_value = 0xFF000000, uint8_t stencil_value = 0x00) const;
@@ -76,6 +77,15 @@ class TestHost {
     assert(stage == 0 && "Only 1 texture stage is fully implemented.");
     texture_stage_enabled_[stage] = enabled;
   }
+
+  // Set up the viewport and fixed function pipeline matrices to match a default XDK project.
+  void SetXDKDefaultViewportAndFixedFunctionMatrices();
+
+  // Set up the viewport and fixed function pipeline matrices to match the nxdk settings.
+  void SetDefaultViewportAndFixedFunctionMatrices();
+
+  void SetViewportOffset(float x, float y, float z, float w) const;
+  void SetViewportScale(float x, float y, float z, float w) const;
 
   void SetFixedFunctionModelViewMatrix(const MATRIX model_matrix);
   void SetFixedFunctionProjectionMatrix(const MATRIX projection_matrix);

--- a/tests/depth_format_tests.cpp
+++ b/tests/depth_format_tests.cpp
@@ -39,6 +39,7 @@ DepthFormatTests::DepthFormatTests(TestHost &host, std::string output_dir)
 }
 
 void DepthFormatTests::Initialize() {
+  TestSuite::Initialize();
   SetDefaultTextureFormat();
 
   auto shader = std::make_shared<PrecalculatedVertexShader>(false);

--- a/tests/front_face_tests.cpp
+++ b/tests/front_face_tests.cpp
@@ -35,9 +35,13 @@ FrontFaceTests::FrontFaceTests(TestHost& host, std::string output_dir)
 }
 
 void FrontFaceTests::Initialize() {
-  // NV097_SET_TEXTURE_FORMAT_COLOR_SZ_X8R8G8B8
-  const TextureFormatInfo& texture_format = kTextureFormats[3];
-  host_.SetTextureFormat(texture_format);
+  TestSuite::Initialize();
+
+  {
+    auto p = pb_begin();
+    p = pb_push1(p, NV20_TCL_PRIMITIVE_3D_CULL_FACE_ENABLE, true);
+    pb_end(p);
+  }
 
   auto shader = std::make_shared<PrecalculatedVertexShader>(false);
   host_.SetShaderProgram(shader);
@@ -65,12 +69,19 @@ void FrontFaceTests::CreateGeometry() {
 
   uint32_t idx = 0;
   buffer->DefineQuad(0, left + 10, top + 4, mid_width - 10, bottom - 10, 10.0f, 10.0f, 10.0f, 10.0f, ul, ll, lr, ur);
+
+  Color tmp = ul;
+  ul = lr;
+  lr = tmp;
+
+  tmp = ur;
+  ur = ll;
+  ll = tmp;
+
   buffer->DefineQuadCW(1, mid_width + 10, top + 4, right - 10, bottom - 10, 10.0f, 10.0f, 10.0f, 10.0f, ul, ll, lr, ur);
 }
 
 void FrontFaceTests::Test(uint32_t front_face, uint32_t cull_face) {
-  host_.SetDepthBufferFormat(NV097_SET_SURFACE_FORMAT_ZETA_Z16);
-  host_.SetDepthBufferFloatMode(false);
   host_.PrepareDraw();
 
   // To verify that the HW is simply preserving a previously set value, force it to a known valid, but different value

--- a/tests/image_blit_tests.cpp
+++ b/tests/image_blit_tests.cpp
@@ -101,6 +101,7 @@ ImageBlitTests::ImageBlitTests(TestHost& host, std::string output_dir)
 }
 
 void ImageBlitTests::Initialize() {
+  TestSuite::Initialize();
   SetDefaultTextureFormat();
 
   SDL_Surface* temp = IMG_Load("D:\\image_blit\\TestImage.png");

--- a/tests/lighting_normal_tests.cpp
+++ b/tests/lighting_normal_tests.cpp
@@ -1,0 +1,206 @@
+#include "lighting_normal_tests.h"
+
+#include <pbkit/pbkit.h>
+
+#include "../test_host.h"
+#include "debug_output.h"
+#include "pbkit_ext.h"
+#include "shaders/precalculated_vertex_shader.h"
+#include "vertex_buffer.h"
+
+struct TestParams {
+  bool set_normal;
+  float normal[3];
+};
+
+static constexpr TestParams kTests[] = {
+    {false, {0.0f, 0.0f, 0.0f}},
+    {true, {0.0f, 0.0f, 1.0f}},
+    {true, {0.0f, 0.0f, -1.0f}},
+    {true, {1.0f, 0.0f, 0.0f}},
+    {true, {0.7071067811865475f, 0.0f, 0.7071067811865475f}},
+    {true, {0.9486832980505138f, 0.0f, 0.31622776601683794f}},
+    {true, {0.24253562503633297f, 0.0f, 0.9701425001453319f}},
+};
+
+LightingNormalTests::LightingNormalTests(TestHost& host, std::string output_dir)
+    : TestSuite(host, std::move(output_dir), "Lighting normals") {
+  for (auto params : kTests) {
+    std::string name = MakeTestName(params.set_normal, params.normal);
+    tests_[name] = [this, params]() { this->Test(params.set_normal, params.normal); };
+  }
+}
+
+void LightingNormalTests::Initialize() {
+  TestSuite::Initialize();
+
+  host_.SetShaderProgram(nullptr);
+  CreateGeometry();
+  host_.SetXDKDefaultViewportAndFixedFunctionMatrices();
+}
+
+void LightingNormalTests::Deinitialize() {
+  normal_bleed_buffer_.reset();
+  lit_buffer_.reset();
+  TestSuite::Deinitialize();
+}
+
+void LightingNormalTests::CreateGeometry() {
+  float left = -2.75f;
+  float right = 2.75f;
+  float top = 1.75f;
+  float bottom = -1.75f;
+  float mid_width = 0.0f;
+
+  {
+    normal_bleed_buffer_ = host_.AllocateVertexBuffer(3);
+    Color one{0.0f, 1.0f, 0.0f, 0.5f};
+    Color two{1.0f, 0.0f, 0.0f, 0.25f};
+    Color three{0.4f, 0.4f, 1.0f, 1.0f};
+
+    float z = 3.0f;
+    float one_pos[3] = {left, top, z};
+    float two_pos[3] = {left + (mid_width - left) * 0.5f, bottom, z};
+    float three_pos[3] = {mid_width, top, z};
+    normal_bleed_buffer_->DefineTriangle(0, one_pos, two_pos, three_pos, one, two, three);
+  }
+
+  {
+    lit_buffer_ = host_.AllocateVertexBuffer(3);
+    Color one{0.4f, 0.1f, 0.1f, 1.0f};
+    Color two{1.0f, 1.0f, 0.4f, 1.0f};
+    Color three{1.0f, 0.6f, 0.3f, 1.0f};
+
+    float z = 1.0f;
+    float one_pos[3] = {mid_width, top, z};
+    float two_pos[3] = {mid_width + (right - mid_width) * 0.5f, bottom, z};
+    float three_pos[3] = {right, top, z};
+    lit_buffer_->DefineTriangle(0, one_pos, two_pos, three_pos, one, two, three);
+  }
+}
+
+static void SetLightAndMaterial() {
+  auto p = pb_begin();
+
+  p = pb_push1(p, NV097_SET_SPECULAR_PARAMS, 0xbf34dce5);
+  p = pb_push1(p, 0x09e4, 0xc020743f);
+  p = pb_push1(p, 0x09e8, 0x40333d06);
+  p = pb_push1(p, 0x09ec, 0xbf003612);
+  p = pb_push1(p, 0x09f0, 0xbff852a5);
+  p = pb_push1(p, 0x09f4, 0x401c1bce);
+
+  p = pb_push1(p, NV097_SET_COLOR_MATERIAL, NV097_SET_COLOR_MATERIAL_ALL_FROM_MATERIAL);
+  pb_push_to(SUBCH_3D, p++, NV097_SET_SCENE_AMBIENT_COLOR, 3);
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+
+  p = pb_push3(p, NV097_SET_MATERIAL_EMISSION, 0x0, 0x0, 0x0);
+  p = pb_push1(p, NV097_SET_MATERIAL_ALPHA, 0x3f800000);  // 1.0
+
+  pb_push_to(SUBCH_3D, p++, NV097_SET_LIGHT_AMBIENT_COLOR, 3);
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+
+  pb_push_to(SUBCH_3D, p++, NV097_SET_LIGHT_DIFFUSE_COLOR, 3);
+  *(p++) = 0x0;
+  *(p++) = 0x3F800000;
+  *(p++) = 0x3F333333;
+
+  pb_push_to(SUBCH_3D, p++, NV097_SET_LIGHT_SPECULAR_COLOR, 3);
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+
+  p = pb_push1(p, NV097_SET_LIGHT_ENABLE_MASK, 0x1);
+
+  p = pb_push1(p, NV097_SET_LIGHT_LOCAL_RANGE, 0x7149f2ca);  // 1e30
+
+  pb_push_to(SUBCH_3D, p++, NV097_SET_LIGHT_INFINITE_HALF_VECTOR, 3);
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  pb_push_to(SUBCH_3D, p++, NV097_SET_LIGHT_INFINITE_DIRECTION, 3);
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x3F800000;  // 1.0f
+
+  pb_end(p);
+}
+
+void LightingNormalTests::Test(bool set_normal, const float* normal) {
+  static constexpr uint32_t kBackgroundColor = 0xFF303030;
+  host_.PrepareDraw(kBackgroundColor);
+
+  uint32_t* p;
+
+  p = pb_begin();
+  p = pb_push1(p, NV097_SET_CLIP_MIN, 0);
+  p = pb_push1(p, NV097_SET_CLIP_MAX, 0x4B7FFFFF);
+  pb_end(p);
+
+  SetLightAndMaterial();
+
+  if (set_normal) {
+    p = pb_begin();
+
+    p = pb_push1(p, NV097_SET_VERTEX_DATA4UB + 0x10, 0);           // Specular
+    p = pb_push1(p, NV097_SET_VERTEX_DATA4UB + 0x1C, 0xFFFFFFFF);  // Back diffuse
+    p = pb_push1(p, NV097_SET_VERTEX_DATA4UB + 0x20, 0);           // Back specular
+
+    p = pb_push1(p, NV097_SET_LIGHTING_ENABLE, 1);
+    p = pb_push1(p, NV097_SET_SPECULAR_ENABLE, 1);
+    p = pb_push1(p, NV097_SET_LIGHT_CONTROL, 0x20001);
+    //    p = pb_push1(p, NV097_SET_LIGHT_ENABLE_MASK, 0);
+
+    pb_end(p);
+
+    Vertex* buf = normal_bleed_buffer_->Lock();
+    int foo = sizeof(buf[0].normal);
+    foo++;
+    memcpy(buf[0].normal, normal, sizeof(buf[0].normal));
+    memcpy(buf[1].normal, normal, sizeof(buf[1].normal));
+    memcpy(buf[2].normal, normal, sizeof(buf[2].normal));
+    normal_bleed_buffer_->Unlock();
+
+    host_.SetVertexBuffer(normal_bleed_buffer_);
+    host_.DrawVertices(host_.POSITION | host_.NORMAL | host_.DIFFUSE);
+  }
+
+  // Render the test subject with no normals but lighting enabled.
+  p = pb_begin();
+  p = pb_push1(p, NV097_SET_LIGHT_CONTROL, 0x10001);
+  p = pb_push1(p, NV097_SET_LIGHTING_ENABLE, 0x1);
+  p = pb_push1(p, NV097_SET_SPECULAR_ENABLE, 0x1);
+  p = pb_push1(p, NV097_SET_LIGHT_ENABLE_MASK, NV097_SET_LIGHT_ENABLE_MASK_LIGHT0_INFINITE);
+
+  p = pb_push1(p, NV097_SET_VERTEX_DATA4UB + 0x10, 0);           // Specular
+  p = pb_push1(p, NV097_SET_VERTEX_DATA4UB + 0x1C, 0xFFFFFFFF);  // Back diffuse
+  p = pb_push1(p, NV097_SET_VERTEX_DATA4UB + 0x20, 0);           // Back specular
+
+  pb_end(p);
+
+  host_.SetVertexBuffer(lit_buffer_);
+  host_.DrawVertices(host_.POSITION | host_.DIFFUSE);
+
+  if (!set_normal) {
+    pb_print("No normal");
+  } else {
+    pb_print("Nx: %g\nNy: %g\nNz: %g\n", normal[0], normal[1], normal[2]);
+  }
+  pb_draw_text_screen();
+
+  std::string name = MakeTestName(set_normal, normal);
+  host_.FinishDrawAndSave(output_dir_, name);
+}
+
+std::string LightingNormalTests::MakeTestName(bool set_normal, const float* normal) {
+  if (!set_normal) {
+    return "NoNormal";
+  }
+
+  char buf[128] = {0};
+  snprintf(buf, 127, "Nz_%d", (int)(normal[2] * 100));
+  return buf;
+}

--- a/tests/lighting_normal_tests.h
+++ b/tests/lighting_normal_tests.h
@@ -1,0 +1,29 @@
+#ifndef NXDK_PGRAPH_TESTS_LIGHTING_NORMAL_TESTS_H
+#define NXDK_PGRAPH_TESTS_LIGHTING_NORMAL_TESTS_H
+
+#include "test_suite.h"
+
+class TestHost;
+class VertexBuffer;
+
+// Tests behavior when lighting is enabled but a normal is not provided in the vertex data.
+// The observed behavior on hardware is that the last set normal is reused for the unspecified vertices.
+class LightingNormalTests : public TestSuite {
+ public:
+  LightingNormalTests(TestHost& host, std::string output_dir);
+
+  void Initialize() override;
+  void Deinitialize() override;
+
+ private:
+  void CreateGeometry();
+  void Test(bool set_normal, const float* normal);
+
+  static std::string MakeTestName(bool set_normal, const float* normal);
+
+ private:
+  std::shared_ptr<VertexBuffer> normal_bleed_buffer_;
+  std::shared_ptr<VertexBuffer> lit_buffer_;
+};
+
+#endif  // NXDK_PGRAPH_TESTS_LIGHTING_NORMAL_TESTS_H

--- a/tests/material_alpha_tests.cpp
+++ b/tests/material_alpha_tests.cpp
@@ -33,6 +33,7 @@ MaterialAlphaTests::MaterialAlphaTests(TestHost& host, std::string output_dir)
 }
 
 void MaterialAlphaTests::Initialize() {
+  TestSuite::Initialize();
   // NV097_SET_TEXTURE_FORMAT_COLOR_SZ_X8R8G8B8
   const TextureFormatInfo& texture_format = kTextureFormats[3];
   host_.SetTextureFormat(texture_format);

--- a/tests/test_suite.cpp
+++ b/tests/test_suite.cpp
@@ -43,3 +43,141 @@ void TestSuite::SetDefaultTextureFormat() const {
   const TextureFormatInfo& texture_format = kTextureFormats[3];
   host_.SetTextureFormat(texture_format);
 }
+
+void TestSuite::Initialize() {
+  auto p = pb_begin();
+  p = pb_push1(p, NV097_SET_LIGHTING_ENABLE, false);
+  p = pb_push1(p, NV097_SET_SPECULAR_ENABLE, false);
+  p = pb_push1(p, NV097_SET_LIGHT_ENABLE_MASK, NV097_SET_LIGHT_ENABLE_MASK_LIGHT0_OFF);
+
+  p = pb_push1(p, NV097_SET_BLEND_ENABLE, 1);
+  p = pb_push1(p, NV097_SET_BLEND_EQUATION, NV097_SET_BLEND_EQUATION_V_FUNC_ADD);
+  p = pb_push1(p, NV097_SET_BLEND_FUNC_SFACTOR, NV097_SET_BLEND_FUNC_SFACTOR_V_SRC_ALPHA);
+  p = pb_push1(p, NV097_SET_BLEND_FUNC_DFACTOR, NV097_SET_BLEND_FUNC_DFACTOR_V_ONE_MINUS_SRC_ALPHA);
+  p = pb_push1(p, 0x17C4, 0);
+  p = pb_push1(p, NV097_SET_FRONT_POLYGON_MODE, NV097_SET_FRONT_POLYGON_MODE_V_FILL);
+  p = pb_push1(p, NV097_SET_BACK_POLYGON_MODE, NV097_SET_FRONT_POLYGON_MODE_V_FILL);
+
+  p = pb_push1(p, NV097_SET_FOG_ENABLE, 0x0);
+  p = pb_push1(p, NV097_SET_COMBINER_SPECULAR_FOG_CW0, 0xe);
+  p = pb_push1(p, NV097_SET_COMBINER_SPECULAR_FOG_CW1, 0x1c80);
+
+  p = pb_push1(p, NV097_SET_VERTEX_DATA4UB + 0x10, 0);           // Specular
+  p = pb_push1(p, NV097_SET_VERTEX_DATA4UB + 0x1C, 0xFFFFFFFF);  // Back diffuse
+  p = pb_push1(p, NV097_SET_VERTEX_DATA4UB + 0x20, 0);           // Back specular
+
+  p = pb_push1(p, 0x318, 0);
+  p = pb_push1(p, 0x31C, 0);
+  p = pb_push1(p, 0x43C, 8);
+
+  p = pb_push1(p, NV097_SET_COMBINER_CONTROL, 1);
+
+  pb_push_to(SUBCH_3D, p++, NV097_SET_COMBINER_COLOR_ICW, 8);
+  *(p++) = 0x4200000;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+
+  pb_push_to(SUBCH_3D, p++, NV097_SET_COMBINER_COLOR_OCW, 8);
+  *(p++) = 0xC00;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+
+  pb_push_to(SUBCH_3D, p++, NV097_SET_COMBINER_ALPHA_ICW, 8);
+  *(p++) = 0x14200000;
+  *(p++) = 0;
+  *(p++) = 0;
+  *(p++) = 0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+
+  pb_push_to(SUBCH_3D, p++, NV097_SET_COMBINER_ALPHA_OCW, 8);
+  *(p++) = 0xC00;
+  *(p++) = 0;
+  *(p++) = 0;
+  *(p++) = 0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+  *(p++) = 0x0;
+
+  p = pb_push1(p, NV097_SET_SHADER_STAGE_PROGRAM, 0x0);
+
+  {
+    uint32_t address = NV097_SET_TEXTURE_ADDRESS;
+    uint32_t control = NV097_SET_TEXTURE_CONTROL0;
+    uint32_t filter = NV097_SET_TEXTURE_FILTER;
+    p = pb_push1(p, address, 0x10101);
+    p = pb_push1(p, control, 0x3ffc0);
+    p = pb_push1(p, filter, 0x1012000);
+
+    address += 0x40;
+    control += 0x40;
+    filter += 0x40;
+    p = pb_push1(p, address, 0x10101);
+    p = pb_push1(p, control, 0x3ffc0);
+    p = pb_push1(p, filter, 0x1012000);
+
+    address += 0x40;
+    control += 0x40;
+    filter += 0x40;
+    p = pb_push1(p, address, 0x10101);
+    p = pb_push1(p, control, 0x3ffc0);
+    p = pb_push1(p, filter, 0x1012000);
+
+    address += 0x40;
+    control += 0x40;
+    filter += 0x40;
+    p = pb_push1(p, address, 0x10101);
+    p = pb_push1(p, control, 0x3ffc0);
+    p = pb_push1(p, filter, 0x1012000);
+  }
+
+  p = pb_push1(p, NV097_SET_FOG_ENABLE, 0x0);
+  p = pb_push1(p, NV097_SET_COMBINER_SPECULAR_FOG_CW0, 0xc);
+  p = pb_push1(p, NV097_SET_COMBINER_SPECULAR_FOG_CW1, 0x1c80);
+
+  {
+    uint32_t matrix_enable = NV097_SET_TEXTURE_MATRIX_ENABLE;
+    p = pb_push1(p, matrix_enable, 0x0);
+    matrix_enable += 4;
+    p = pb_push1(p, matrix_enable, 0x0);
+    matrix_enable += 4;
+    p = pb_push1(p, matrix_enable, 0x0);
+    matrix_enable += 4;
+    p = pb_push1(p, matrix_enable, 0x0);
+  }
+
+  p = pb_push1(p, NV097_SET_LIGHTING_ENABLE, 0);
+  p = pb_push1(p, NV097_SET_SPECULAR_ENABLE, 0);
+  p = pb_push1(p, NV097_SET_LIGHT_CONTROL, 0x20001);
+  p = pb_push1(p, NV097_SET_LIGHT_ENABLE_MASK, 0);
+
+  p = pb_push1(p, NV097_SET_FRONT_FACE, NV097_SET_FRONT_FACE_V_CCW);
+  p = pb_push1(p, NV097_SET_CULL_FACE, NV097_SET_CULL_FACE_V_BACK);
+
+  p = pb_push1(p, NV097_SET_DEPTH_MASK, true);
+  p = pb_push1(p, NV097_SET_DEPTH_FUNC, NV097_SET_DEPTH_FUNC_V_LESS);
+  p = pb_push1(p, NV097_SET_STENCIL_TEST_ENABLE, false);
+  p = pb_push1(p, NV097_SET_STENCIL_MASK, true);
+
+  pb_end(p);
+
+  host_.SetDefaultViewportAndFixedFunctionMatrices();
+  host_.SetDepthBufferFormat(NV097_SET_SURFACE_FORMAT_ZETA_Z16);
+  host_.SetDepthBufferFloatMode(false);
+
+  SetDefaultTextureFormat();
+  host_.SetTextureStageEnabled(0, false);
+}

--- a/tests/test_suite.h
+++ b/tests/test_suite.h
@@ -13,7 +13,7 @@ class TestSuite {
 
   const std::string &Name() const { return test_name_; };
 
-  virtual void Initialize() = 0;
+  virtual void Initialize();
   virtual void Deinitialize() {}
 
   std::vector<std::string> TestNames() const;

--- a/tests/texture_format_tests.cpp
+++ b/tests/texture_format_tests.cpp
@@ -24,6 +24,7 @@ TextureFormatTests::TextureFormatTests(TestHost &host, std::string output_dir)
 }
 
 void TextureFormatTests::Initialize() {
+  TestSuite::Initialize();
   CreateGeometry();
 
   host_.SetDepthBufferFormat(NV097_SET_SURFACE_FORMAT_ZETA_Z24S8);

--- a/tests/two_d_line_tests.cpp
+++ b/tests/two_d_line_tests.cpp
@@ -44,6 +44,7 @@ TwoDLineTests::TwoDLineTests(TestHost& host, std::string output_dir)
 }
 
 void TwoDLineTests::Initialize() {
+  TestSuite::Initialize();
   SetDefaultTextureFormat();
 
   auto channel = kNextContextChannel;

--- a/vertex_buffer.h
+++ b/vertex_buffer.h
@@ -58,7 +58,28 @@ class VertexBuffer {
 
   uint32_t GetNumVertices() const { return num_vertices_; }
 
+  void SetCacheValid(bool valid = true) { cache_valid_ = valid; }
+  bool IsCacheValid() const { return cache_valid_; }
+
   void Linearize(float texture_width, float texture_height);
+
+  // Defines a triangle with the give 3-element vertices.
+  void DefineTriangle(uint32_t start_index, const float* one, const float* two, const float* three);
+  void DefineTriangle(uint32_t start_index, const float* one, const float* two, const float* three,
+                      const float* normal_one, const float* normal_two, const float* normal_three);
+  void DefineTriangle(uint32_t start_index, const float* one, const float* two, const float* three,
+                      const Color& one_diffuse, const Color& two_diffuse, const Color& three_diffuse);
+  void DefineTriangle(uint32_t start_index, const float* one, const float* two, const float* three,
+                      const float* normal_one, const float* normal_two, const float* normal_three,
+                      const Color& diffuse_one, const Color& diffuse_two, const Color& diffuse_three);
+  void DefineTriangleCW(uint32_t start_index, const float* one, const float* two, const float* three);
+  void DefineTriangleCW(uint32_t start_index, const float* one, const float* two, const float* three,
+                        const float* normal_one, const float* normal_two, const float* normal_three);
+  void DefineTriangleCW(uint32_t start_index, const float* one, const float* two, const float* three,
+                        const Color& diffuse_one, const Color& diffuse_two, const Color& diffuse_three);
+  void DefineTriangleCW(uint32_t start_index, const float* one, const float* two, const float* three,
+                        const float* normal_one, const float* normal_two, const float* normal_three,
+                        const Color& diffuse_one, const Color& diffuse_two, const Color& diffuse_three);
 
   void DefineQuad(uint32_t start_index, float left, float top, float right, float bottom);
   void DefineQuad(uint32_t start_index, float left, float top, float right, float bottom, float z);
@@ -86,6 +107,8 @@ class VertexBuffer {
   uint32_t num_vertices_;
   Vertex* linear_vertex_buffer_ = nullptr;      // texcoords 0 to kFramebufferWidth/kFramebufferHeight
   Vertex* normalized_vertex_buffer_ = nullptr;  // texcoords normalized 0 to 1
+
+  bool cache_valid_{false};  // Indicates whether the HW should be forced to reload this buffer.
 };
 
 #endif  // NXDK_PGRAPH_TESTS__VERTEX_BUFFER_H_


### PR DESCRIPTION
Adds a test to showcase the behavior where the XBOX hw preserves the last used vertex normal when rendering lit vertices that do not provide a normal themselves.

Also fixes various issues related to state bleeding and sets the foundation for #22. Normally I'd split this into a separate PR but the state reset is critical to keeping the other tests from breaking, and in this specific case I don't think it's worth leaving things in a broken state just for the sake of a clean git history.