### PR TITLE
Adds tests for more draw methods.

### DIFF
--- a/pbkit_ext.h
+++ b/pbkit_ext.h
@@ -24,6 +24,21 @@
 
 #define MASK(mask, val) (((val) << (ffs(mask) - 1)) & (mask))
 
+// Indicates that all values being pushed in a pb_push* invocation should be sent to the same command.
+//
+// The default behavior is for pgraph commands that do not operate on fixed size arrays to treat multiple parameters as
+// invocations of subsequent pgraph commands.
+// E.g., NV097_INLINE_ARRAY (0x00001818) expects a single parameter which is added to the inline array being built up
+// in graphics memory. Rather than invoke pb_push1 many times over and waste time/space re-sending the
+// NV097_INLINE_ARRAY command, it is desirable to send multiple components (e.g., all 3 coordinates for a vertex) in a
+// single push. Setting bit 30 (i.e., NV2A_SUPPRESS_COMMAND_INCREMENT(NV097_INLINE_ARRAY)) instructs the pushbuffer to
+// treat all the parameters in the command packet as part of the NV097_INLINE_ARRAY command.
+// Failure to set bit 30 would utilize the default behavior, so the first parameter would go to NV097_INLINE_ARRAY, but
+// the next would go to NV097_SET_EYE_VECTOR (0x0000181C), which itself will expect 3 parameters and will at best lead
+// to unexpected behavior and potentially an exception being raised by the hardware depending on how many parameters in
+// total are being sent.
+#define NV2A_SUPPRESS_COMMAND_INCREMENT(cmd) (0x40000000 | (cmd))
+
 void set_depth_stencil_buffer_region(uint32_t depth_buffer_format, uint32_t depth_value, uint8_t stencil_value,
                                      uint32_t left, uint32_t top, uint32_t width, uint32_t height);
 

--- a/test_host.h
+++ b/test_host.h
@@ -28,10 +28,23 @@ class TestHost {
  public:
   enum VertexFormatElements {
     POSITION = 1 << NV2A_VERTEX_ATTR_POSITION,
-    TEXCOORD0 = 1 << NV2A_VERTEX_ATTR_TEXTURE0,
     NORMAL = 1 << NV2A_VERTEX_ATTR_NORMAL,
     DIFFUSE = 1 << NV2A_VERTEX_ATTR_DIFFUSE,
     SPECULAR = 1 << NV2A_VERTEX_ATTR_SPECULAR,
+    TEXCOORD0 = 1 << NV2A_VERTEX_ATTR_TEXTURE0,
+  };
+
+  enum DrawPrimitive {
+    PRIMITIVE_POINTS = NV097_SET_BEGIN_END_OP_POINTS,
+    PRIMITIVE_LINES = NV097_SET_BEGIN_END_OP_LINES,
+    PRIMITIVE_LINE_LOOP = NV097_SET_BEGIN_END_OP_LINE_LOOP,
+    PRIMITIVE_LINE_STRIP = NV097_SET_BEGIN_END_OP_LINE_STRIP,
+    PRIMITIVE_TRIANGLES = NV097_SET_BEGIN_END_OP_TRIANGLES,
+    PRIMITIVE_TRIANGLE_STRIP = NV097_SET_BEGIN_END_OP_TRIANGLE_STRIP,
+    PRIMITIVE_TRIANGLE_FAN = NV097_SET_BEGIN_END_OP_TRIANGLE_FAN,
+    PRIMITIVE_QUADS = NV097_SET_BEGIN_END_OP_QUADS,
+    PRIMITIVE_QUAD_STRIP = NV097_SET_BEGIN_END_OP_QUAD_STRIP,
+    PRIMITIVE_POLYGON = NV097_SET_BEGIN_END_OP_POLYGON,
   };
 
  public:
@@ -65,8 +78,21 @@ class TestHost {
   static void EraseText();
 
   void PrepareDraw(uint32_t argb = 0xFF000000, uint32_t depth_value = 0xFF000000, uint8_t stencil_value = 0x00);
-  void DrawVertices(uint32_t elements = 0xFFFFFFFF);
-  void DrawVerticesAsInlineBuffer(uint32_t enabled_fields = 0xFFFFFFFF);
+
+  void DrawArrays(uint32_t enabled_vertex_fields = 0xFFFFFFFF, DrawPrimitive primitive = PRIMITIVE_TRIANGLES);
+  void DrawInlineBuffer(uint32_t enabled_vertex_fields = 0xFFFFFFFF, DrawPrimitive primitive = PRIMITIVE_TRIANGLES);
+
+  // Sends vertices as an interleaved array of vertex fields. E.g., [POS_0,DIFFUSE_0,POS_1,DIFFUSE_1,...]
+  void DrawInlineArray(uint32_t enabled_vertex_fields = 0xFFFFFFFF, DrawPrimitive primitive = PRIMITIVE_TRIANGLES);
+
+  // Sends vertices via an index array. Index values must be < 0xFFFF and are sent two per command.
+  void DrawInlineElements16(const std::vector<uint32_t> &indices, uint32_t enabled_vertex_fields = 0xFFFFFFFF,
+                            DrawPrimitive primitive = PRIMITIVE_TRIANGLES);
+
+  // Sends vertices via an index array. Index values are unsigned integers.
+  void DrawInlineElements32(const std::vector<uint32_t> &indices, uint32_t enabled_vertex_fields = 0xFFFFFFFF,
+                            DrawPrimitive primitive = PRIMITIVE_TRIANGLES);
+
   void FinishDraw() const;
   void FinishDrawAndSave(const std::string &output_directory, const std::string &name,
                          const std::string &z_buffer_name = "");

--- a/tests/depth_format_tests.cpp
+++ b/tests/depth_format_tests.cpp
@@ -60,7 +60,7 @@ void DepthFormatTests::Test(const DepthFormat &format, bool compress_z, uint32_t
   p = pb_push1(p, NV097_SET_STENCIL_MASK, false);
   pb_end(p);
 
-  host_.DrawVertices();
+  host_.DrawArrays();
 
   const char *format_name = format.format == NV097_SET_SURFACE_FORMAT_ZETA_Z16 ? "z16" : "z24";
   pb_print("DF: %s\n", format_name);

--- a/tests/front_face_tests.cpp
+++ b/tests/front_face_tests.cpp
@@ -105,7 +105,7 @@ void FrontFaceTests::Test(uint32_t front_face, uint32_t cull_face) {
   p = pb_push1(p, NV097_SET_FRONT_FACE, front_face);
   p = pb_push1(p, NV097_SET_CULL_FACE, cull_face);
   pb_end(p);
-  host_.DrawVertices();
+  host_.DrawArrays();
 
   std::string winding_name = WindingName(front_face);
   pb_print("FF: %s\n", winding_name.c_str());

--- a/tests/lighting_normal_tests.h
+++ b/tests/lighting_normal_tests.h
@@ -1,6 +1,9 @@
 #ifndef NXDK_PGRAPH_TESTS_LIGHTING_NORMAL_TESTS_H
 #define NXDK_PGRAPH_TESTS_LIGHTING_NORMAL_TESTS_H
 
+#include <memory>
+#include <vector>
+
 #include "test_suite.h"
 
 class TestHost;
@@ -10,6 +13,14 @@ class VertexBuffer;
 // The observed behavior on hardware is that the last set normal is reused for the unspecified vertices.
 class LightingNormalTests : public TestSuite {
  public:
+  enum DrawMode {
+    DRAW_ARRAYS,
+    DRAW_INLINE_BUFFERS,
+    DRAW_INLINE_ARRAYS,
+    DRAW_INLINE_ELEMENTS,
+  };
+
+ public:
   LightingNormalTests(TestHost& host, std::string output_dir);
 
   void Initialize() override;
@@ -17,13 +28,15 @@ class LightingNormalTests : public TestSuite {
 
  private:
   void CreateGeometry();
-  void Test(bool set_normal, const float* normal, bool use_inline_buffer);
+  void Test(bool set_normal, const float* normal, DrawMode draw_mode);
 
-  static std::string MakeTestName(bool set_normal, const float* normal, bool inline_buffer);
+  static std::string MakeTestName(bool set_normal, const float* normal, DrawMode draw_mode);
 
  private:
   std::shared_ptr<VertexBuffer> normal_bleed_buffer_;
   std::shared_ptr<VertexBuffer> lit_buffer_;
+
+  std::vector<uint32_t> lit_index_buffer_;
 };
 
 #endif  // NXDK_PGRAPH_TESTS_LIGHTING_NORMAL_TESTS_H

--- a/tests/material_alpha_tests.cpp
+++ b/tests/material_alpha_tests.cpp
@@ -171,7 +171,7 @@ void MaterialAlphaTests::Test(uint32_t diffuse_source, float material_alpha) {
 
   pb_end(p);
 
-  host_.DrawVertices(host_.POSITION | host_.NORMAL | host_.DIFFUSE | host_.SPECULAR);
+  host_.DrawArrays(host_.POSITION | host_.NORMAL | host_.DIFFUSE | host_.SPECULAR);
 
   std::string source = DiffuseSourceName(diffuse_source);
   pb_print("Src: %s\n", source.c_str());

--- a/tests/test_suite.cpp
+++ b/tests/test_suite.cpp
@@ -172,6 +172,7 @@ void TestSuite::Initialize() {
 
   p = pb_push1(p, NV097_SET_FRONT_FACE, NV097_SET_FRONT_FACE_V_CCW);
   p = pb_push1(p, NV097_SET_CULL_FACE, NV097_SET_CULL_FACE_V_BACK);
+  p = pb_push1(p, NV097_SET_CULL_FACE_ENABLE, true);
 
   p = pb_push1(p, NV097_SET_DEPTH_MASK, true);
   p = pb_push1(p, NV097_SET_DEPTH_FUNC, NV097_SET_DEPTH_FUNC_V_LESS);

--- a/tests/texture_format_tests.cpp
+++ b/tests/texture_format_tests.cpp
@@ -55,7 +55,7 @@ void TextureFormatTests::Test(const TextureFormatInfo &texture_format) {
   }
 
   host_.PrepareDraw();
-  host_.DrawVertices();
+  host_.DrawArrays();
 
   /* PrepareDraw some text on the screen */
   pb_print("N: %s\n", texture_format.name);

--- a/vertex_buffer.h
+++ b/vertex_buffer.h
@@ -2,6 +2,7 @@
 #define NXDK_PGRAPH_TESTS__VERTEX_BUFFER_H_
 
 #include <cstdint>
+#include <vector>
 
 #define TO_ARGB(float_vals)                                                                  \
   (((uint32_t)(float_vals[0] * 255.0f) << 24) + ((uint32_t)(float_vals[1] * 255.0f) << 16) + \


### PR DESCRIPTION
Specifically for inline arrays (vertex data is specified via tightly packed, interleaved arrays populated via `NV097_INLINE_ARRAY`) and inline elements (vertex data is still specified via `NV097_SET_VERTEX_DATA_ARRAY_OFFSET` but indices are provided via either `NV097_ARRAY_ELEMENT16` or `NV097_ARRAY_ELEMENT32`).