### PR TITLE
Fix auto path detection for non readonly media

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,8 +103,7 @@ bool get_xbe_directory(std::string& xbe_root_directory) {
     }
     return true;
   }
-
-  xbe_root_directory = "D:";
+  xbe_root_directory = xbe_directory.substr(0, xbe_directory.find_last_of("\\"));
   return true;
 }
 


### PR DESCRIPTION
can you test that on hw?  I think my original commit forgot to remove the default.xbe from the path...