### PR TITLE
Fixes exception when rendering untexturable-primitives.

### DIFF
--- a/src/tests/test_suite.cpp
+++ b/src/tests/test_suite.cpp
@@ -171,7 +171,7 @@ void TestSuite::Initialize() {
 
   SetDefaultTextureFormat();
   host_.SetTextureStageEnabled(0, false);
-  host_.SetShaderStageProgram(TestHost::STAGE_2D_PROJECTIVE);
+  host_.SetShaderStageProgram(TestHost::STAGE_NONE);
   host_.SetShaderStageInput(0, 0);
 
   host_.ClearAllVertexAttributeStrideOverrides();

--- a/src/tests/texture_format_tests.cpp
+++ b/src/tests/texture_format_tests.cpp
@@ -49,6 +49,7 @@ void TextureFormatTests::Initialize() {
   shader->SetLightingEnabled(false);
   host_.SetShaderProgram(shader);
   host_.SetTextureStageEnabled(0, true);
+  host_.SetShaderStageProgram(TestHost::STAGE_2D_PROJECTIVE);
 }
 
 void TextureFormatTests::CreateGeometry() {


### PR DESCRIPTION
Attempts to render 3d lines trigger an exception if the shader stage program is projective.