### PR TITLE
Enable optimization and use a faster PNG encoder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = third_party/nxdk
 	url = https://github.com/abaire/nxdk.git
 
+[submodule "third_party/fpng"]
+	path = third_party/fpng
+	url = https://github.com/richgel999/fpng

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,8 @@ SRCS = \
 	$(SRCDIR)/texture_stage.cpp \
 	$(SRCDIR)/vertex_buffer.cpp \
 	$(THIRDPARTYDIR)/swizzle.c \
-	$(THIRDPARTYDIR)/printf/printf.c
+	$(THIRDPARTYDIR)/printf/printf.c \
+	$(THIRDPARTYDIR)/fpng/src/fpng.cpp
 
 SHADER_OBJS = \
 	$(SRCDIR)/shaders/attribute_carryover_test.inl \
@@ -75,9 +76,13 @@ SHADER_OBJS = \
 	$(SRCDIR)/shaders/textured_pixelshader.inl \
 	$(SRCDIR)/shaders/untextured_pixelshader.inl
 
-DEBUG := y
 CFLAGS += -I$(SRCDIR) -I$(THIRDPARTYDIR)
-CXXFLAGS += -I$(SRCDIR) -I$(THIRDPARTYDIR)
+CXXFLAGS += -I$(SRCDIR) -I$(THIRDPARTYDIR) -DFPNG_NO_STDIO=1 -DFPNG_NO_SSE=1
+
+ifneq ($(DEBUG),y)
+CFLAGS += -O3 -fno-strict-aliasing
+CXXFLAGS += -O3 -fno-strict-aliasing
+endif
 
 # Disable automatic test execution if no input is detected.
 DISABLE_AUTORUN ?= n


### PR DESCRIPTION
Brings total runtime down considerably. Including all but your depth format tests, this brings runtime down to about a minute in xemu. With the depth format tests at around 3.5 min. The new image encoder basically cuts test time in half after optimizations are enabled. I'm sure there are several more improvement opportunities, but this gets the lowest hanging fruit. Another low fruit would be syncing with upstream nxdk and enabling LTO for possible improvements.

I have not tested on hardware.