### PR TITLE
Adds register checking.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,9 @@ SRCS = \
 	$(SRCDIR)/logger.cpp \
 	$(SRCDIR)/main.cpp \
 	$(SRCDIR)/math3d.c \
-	$(SRCDIR)/pbkit_ext.cpp \
 	$(SRCDIR)/menu_item.cpp \
+	$(SRCDIR)/pbkit_ext.cpp \
+	$(SRCDIR)/pgraph_diff_token.cpp \
 	$(SRCDIR)/shaders/orthographic_vertex_shader.cpp \
 	$(SRCDIR)/shaders/perspective_vertex_shader.cpp \
 	$(SRCDIR)/shaders/pixel_shader_program.cpp \
@@ -141,6 +142,13 @@ endif
 ENABLE_PROGRESS_LOG ?= n
 ifeq ($(ENABLE_PROGRESS_LOG),y)
 CXXFLAGS += -DENABLE_PROGRESS_LOG
+endif
+
+# Causes a diff of the nv2a PGRAPH registers to be done between the start and end of each test in order to detect state
+# leakage. Output is logged to XBDM and will be written into the progress log if it is enabled.
+ENABLE_PGRAPH_REGION_DIFF ?= n
+ifeq ($(ENABLE_PGRAPH_REGION_DIFF),y)
+CXXFLAGS += -DENABLE_PGRAPH_REGION_DIFF
 endif
 
 CLEANRULES = clean-resources

--- a/src/pbkit_ext.cpp
+++ b/src/pbkit_ext.cpp
@@ -3,6 +3,7 @@
 #include <pbkit/pbkit.h>
 
 #include <cmath>
+#include <vector>
 
 #include "debug_output.h"
 #include "nxdk_ext.h"
@@ -193,4 +194,64 @@ uint32_t *pb_push3f(uint32_t *p, DWORD command, float param1, float param2, floa
   *((float *)(p + 2)) = param2;
   *((float *)(p + 3)) = param3;
   return p + 4;
+}
+
+void pb_fetch_pgraph_registers(uint8_t *registers) {
+  // See https://github.com/XboxDev/nv2a-trace/blob/65bdd2369a5b216cfc47c9545f870c49d118276b/Trace.py#L32
+
+  while (pb_busy()) {
+    /* Wait for any pending pgraph commands to be flushed */
+  }
+
+  const auto kPGRAPHRegisterBase = reinterpret_cast<const uint32_t *>(PGRAPH_REGISTER_BASE);
+  const auto kPGRAPHRegisterEnd = PGRAPH_REGISTER_BASE + PGRAPH_REGISTER_ARRAY_SIZE;
+
+  struct Range {
+    uint32_t begin;
+    uint32_t end;
+  };
+
+  // clang-format off
+  static constexpr Range kReadRanges[] = {
+      {PGRAPH_REGISTER_BASE, 0xFD400200}, // From nv2a-trace: "0xFD400200 hangs Xbox, I just skipped to 0x400."
+      // Spotchecked 300, 360, 3B0, 3F0 also hang
+      {0xFD400400, 0xFD400754}, // From xemu, 0xFD400754 is the RDI interface.
+      {0xFD400758, kPGRAPHRegisterEnd},
+  };
+  // clang-format on
+
+  // Read a dword at a time as the target is MMIO.
+  uint32_t *last_empty = nullptr;
+  for (const auto &range : kReadRanges) {
+    auto src = reinterpret_cast<const uint32_t *>(range.begin);
+    auto end = reinterpret_cast<const uint32_t *>(range.end);
+    auto offset = range.begin - PGRAPH_REGISTER_BASE;
+    auto dst = reinterpret_cast<uint32_t *>(registers + offset);
+
+    while (last_empty && last_empty < dst) {
+      *last_empty++ = 0xBAD0BAD0;
+    }
+
+    while (src < end) {
+      if ((intptr_t)src >= 0xFD400200 && (intptr_t)src < 0xFD400400) {
+        PrintMsg("Checking 0x%p\n", src);
+        Sleep(10);
+      }
+      *dst++ = *src++;
+    }
+    last_empty = dst;
+  }
+}
+
+void pb_diff_registers(const uint8_t *a, const uint8_t *b, std::list<uint32_t> &modified_registers) {
+  modified_registers.clear();
+
+  auto old_val = reinterpret_cast<const uint32_t *>(a);
+  auto new_val = reinterpret_cast<const uint32_t *>(b);
+
+  for (auto i = 0; i < PGRAPH_REGISTER_ARRAY_SIZE / 4; ++i, ++old_val, ++new_val) {
+    if (*old_val != *new_val) {
+      modified_registers.push_back(PGRAPH_REGISTER_BASE + i * 4);
+    }
+  }
 }

--- a/src/pbkit_ext.h
+++ b/src/pbkit_ext.h
@@ -6,6 +6,7 @@
 #include <strings.h>
 
 #include <cstdint>
+#include <list>
 
 // From pbkit.c
 #define MAXRAM 0x03FFAFFF
@@ -85,5 +86,14 @@ uint32_t* pb_push3f(uint32_t* p, DWORD command, float param1, float param2, floa
 // support floats.
 void pb_print_with_floats(const char* format, ...);
 #define pb_print pb_print_with_floats
+
+#define PGRAPH_REGISTER_BASE 0xFD400000
+#define PGRAPH_REGISTER_ARRAY_SIZE 0x2000
+
+// Fetches (most of) the PGRAPH region from the nv2a hardware.
+// `registers` must be an array of at least size PGRAPH_REGISTER_ARRAY_SIZE bytes.
+void pb_fetch_pgraph_registers(uint8_t* registers);
+
+void pb_diff_registers(const uint8_t* a, const uint8_t* b, std::list<uint32_t>& modified_registers);
 
 #endif  // NXDK_PGRAPH_TESTS_PBKIT_EXT_H

--- a/src/pgraph_diff_token.cpp
+++ b/src/pgraph_diff_token.cpp
@@ -1,0 +1,60 @@
+#include "pgraph_diff_token.h"
+
+#include <set>
+#include <vector>
+
+#include "debug_output.h"
+
+#ifdef ENABLE_PROGRESS_LOG
+#include "logger.h"
+#endif
+
+// This list was compiled by comparing the raw diff across a NV097_SET_SHADOW_COMPARE_FUNC to a diff across a
+// NV097_SET_MATERIAL_ALPHA. Addresses that were modified in both are assumed to be utility registers without any
+// particularly interesting meaning.
+static std::set<uint32_t> kDiffBlacklist{
+    0xFD40000C, 0xFD40010C, 0xFD400704, 0xFD400708, 0xFD40070C, 0xFD40072C, 0xFD400740, 0xFD400744,
+    0xFD400748, 0xFD40074C,
+    0xFD400750,  // Value changes even when no pgraph commands are set
+    0xFD400760, 0xFD400764, 0xFD400768, 0xFD40076C, 0xFD400788, 0xFD4007A0, 0xFD4007A4, 0xFD4007A8,
+    0xFD4007AC, 0xFD4007B0, 0xFD4007B4, 0xFD4007B8, 0xFD4007BC, 0xFD4007E0, 0xFD4007E4, 0xFD4007E8,
+    0xFD4007EC, 0xFD4007F0, 0xFD4007F4, 0xFD4007F8, 0xFD4007FC, 0xFD40110C, 0xFD401704, 0xFD401708,
+    0xFD40170C, 0xFD40172C, 0xFD401740, 0xFD401744, 0xFD401748, 0xFD40174C,
+    0xFD401750,  // Value changes even when no pgraph commands are set
+    0xFD401760, 0xFD401764, 0xFD401768, 0xFD40176C, 0xFD401788, 0xFD4017A0, 0xFD4017A4, 0xFD4017A8,
+    0xFD4017AC, 0xFD4017B0, 0xFD4017B4, 0xFD4017B8, 0xFD4017BC, 0xFD4017E0, 0xFD4017E4, 0xFD4017E8,
+    0xFD4017EC, 0xFD4017F0, 0xFD4017F4, 0xFD4017F8, 0xFD4017FC,
+};
+
+PGRAPHDiffToken::PGRAPHDiffToken(bool initialize) : registers{0} {
+  if (initialize) {
+    Capture();
+  }
+}
+
+void PGRAPHDiffToken::Capture() { pb_fetch_pgraph_registers(registers); }
+
+void PGRAPHDiffToken::DumpDiff() const {
+  std::vector<uint8_t> new_registers;
+  new_registers.resize(PGRAPH_REGISTER_ARRAY_SIZE);
+  pb_fetch_pgraph_registers(new_registers.data());
+
+  std::list<uint32_t> modified_registers;
+  pb_diff_registers(registers, new_registers.data(), modified_registers);
+
+  auto old_vals = reinterpret_cast<const uint32_t*>(registers);
+  auto new_vals = reinterpret_cast<const uint32_t*>(new_registers.data());
+
+  for (auto addr : modified_registers) {
+    //    if (kDiffBlacklist.find(addr) != kDiffBlacklist.end()) {
+    //      continue;
+    //    }
+    const auto offset = (addr - PGRAPH_REGISTER_BASE) / 4;
+    PrintMsg("0x%08X: 0x%08X => 0x%08X\n", addr, old_vals[offset], new_vals[offset]);
+
+#ifdef ENABLE_PROGRESS_LOG
+    Logger::Log() << std::setw(8) << std::hex << "0x" << addr << ": 0x" << old_vals[offset] << " => 0x"
+                  << new_vals[offset] << std::endl;
+#endif
+  }
+}

--- a/src/pgraph_diff_token.h
+++ b/src/pgraph_diff_token.h
@@ -1,0 +1,14 @@
+#ifndef NXDK_PGRAPH_TESTS_PGRAPH_DIFF_TOKEN_H
+#define NXDK_PGRAPH_TESTS_PGRAPH_DIFF_TOKEN_H
+
+#include "pbkit_ext.h"
+
+struct PGRAPHDiffToken {
+  uint8_t registers[PGRAPH_REGISTER_ARRAY_SIZE];
+
+  explicit PGRAPHDiffToken(bool initialize = true);
+  void Capture();
+  void DumpDiff() const;
+};
+
+#endif  // NXDK_PGRAPH_TESTS_PGRAPH_DIFF_TOKEN_H

--- a/src/tests/material_alpha_tests.cpp
+++ b/src/tests/material_alpha_tests.cpp
@@ -155,12 +155,15 @@ void MaterialAlphaTests::Test(uint32_t diffuse_source, float material_alpha) {
   p = pb_push1(p, NV097_SET_MATERIAL_EMISSION, 0x0);
   p = pb_push1(p, NV097_SET_MATERIAL_EMISSION + 4, 0x0);
   p = pb_push1(p, NV097_SET_MATERIAL_EMISSION + 8, 0x0);
+  pb_end(p);
 
   // Material's diffuse alpha float
+  PGRAPHDiffToken diff_token;
+  p = pb_begin();
   uint32_t alpha_int = *(uint32_t*)&material_alpha;
   p = pb_push1(p, NV097_SET_MATERIAL_ALPHA, alpha_int);
-
   pb_end(p);
+  diff_token.DumpDiff();
 
   host_.DrawArrays(host_.POSITION | host_.NORMAL | host_.DIFFUSE | host_.SPECULAR);
 

--- a/src/tests/test_suite.cpp
+++ b/src/tests/test_suite.cpp
@@ -12,7 +12,7 @@
 #define SET_MASK(mask, val) (((val) << (__builtin_ffs(mask) - 1)) & (mask))
 
 TestSuite::TestSuite(TestHost& host, std::string output_dir, std::string suite_name)
-    : host_(host), output_dir_(std::move(output_dir)), suite_name_(std::move(suite_name)) {
+    : host_(host), output_dir_(std::move(output_dir)), suite_name_(std::move(suite_name)), pgraph_diff_(false) {
   output_dir_ += "\\";
   output_dir_ += suite_name_;
   std::replace(output_dir_.begin(), output_dir_.end(), ' ', '_');
@@ -218,6 +218,16 @@ void TestSuite::Initialize() {
   PixelShaderProgram::DisablePixelShader();
 
   host_.ClearAllVertexAttributeStrideOverrides();
+
+#ifdef ENABLE_PGRAPH_REGION_DIFF
+  pgraph_diff_.Capture();
+#endif
+}
+
+void TestSuite::Deinitialize() {
+#ifdef ENABLE_PGRAPH_REGION_DIFF
+  pgraph_diff_.DumpDiff();
+#endif
 }
 
 std::chrono::steady_clock::time_point TestSuite::LogTestStart(const std::string& test_name) {

--- a/src/tests/test_suite.h
+++ b/src/tests/test_suite.h
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+#include "pgraph_diff_token.h"
+
 class TestHost;
 
 class TestSuite {
@@ -16,7 +18,7 @@ class TestSuite {
   const std::string &Name() const { return suite_name_; };
 
   virtual void Initialize();
-  virtual void Deinitialize() {}
+  virtual void Deinitialize();
 
   void DisableTests(const std::vector<std::string> &tests_to_skip);
 
@@ -43,6 +45,8 @@ class TestSuite {
 
   // Map of `test_name` to `void test()`
   std::map<std::string, std::function<void()>> tests_{};
+
+  PGRAPHDiffToken pgraph_diff_;
 };
 
 #endif  // NXDK_PGRAPH_TESTS_TEST_SUITE_H

--- a/src/tests/texture_shadow_comparator_tests.cpp
+++ b/src/tests/texture_shadow_comparator_tests.cpp
@@ -626,9 +626,11 @@ void TextureShadowComparatorTests::TestProjected(uint32_t depth_format, uint32_t
   host_.SetFinalCombiner1Just(TestHost::SRC_DIFFUSE, true);
 
   auto &stage = host_.GetTextureStage(0);
+  PGRAPHDiffToken diff_token;
   p = pb_begin();
   p = pb_push1(p, NV097_SET_SHADOW_COMPARE_FUNC, shadow_comp_function);
   pb_end(p);
+  diff_token.DumpDiff();
 
   host_.SetShaderStageProgram(TestHost::STAGE_3D_PROJECTIVE);
   stage.SetFormat(GetTextureFormatInfo(texture_format));


### PR DESCRIPTION
Lays the groundwork for #52 
More work needs to be done to ignore general utility registers and to validate the mapping between these addresses and the values used in xemu's https://github.com/mborgerson/xemu/blob/master/hw/xbox/nv2a/nv2a_regs.h