### PR TITLE
Adds test for stencil ops with enabled/disabled depth/stencil tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ SRCS = \
 	$(SRCDIR)/tests/null_surface_tests.cpp \
 	$(SRCDIR)/tests/overlapping_draw_modes_tests.cpp \
 	$(SRCDIR)/tests/set_vertex_data_tests.cpp \
+	$(SRCDIR)/tests/stencil_tests.cpp \
 	$(SRCDIR)/tests/surface_clip_tests.cpp \
 	$(SRCDIR)/tests/surface_pitch_tests.cpp \
 	$(SRCDIR)/tests/test_suite.cpp \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,7 @@
 #include "tests/surface_pitch_tests.h"
 #include "tests/texgen_matrix_tests.h"
 #include "tests/texgen_tests.h"
+#include "tests/stencil_tests.h"
 #include "tests/texture_border_tests.h"
 #include "tests/texture_format_dxt_tests.h"
 #include "tests/texture_format_tests.h"
@@ -388,6 +389,10 @@ static void register_suites(TestHost& host, std::vector<std::shared_ptr<TestSuit
   }
   {
     auto suite = std::make_shared<SurfacePitchTests>(host, output_directory);
+    test_suites.push_back(std::dynamic_pointer_cast<TestSuite>(suite));
+  }
+  {
+    auto suite = std::make_shared<StencilTests>(host, output_directory);
     test_suites.push_back(std::dynamic_pointer_cast<TestSuite>(suite));
   }
   {

--- a/src/tests/stencil_tests.cpp
+++ b/src/tests/stencil_tests.cpp
@@ -1,0 +1,168 @@
+#include "stencil_tests.h"
+
+#include <pbkit/pbkit.h>
+
+#include "shaders/precalculated_vertex_shader.h"
+#include "test_host.h"
+#include "debug_output.h"
+#include "nxdk_ext.h"
+#include "pbkit_ext.h"
+#include "vertex_buffer.h"
+
+constexpr StencilTests::StencilParams kStencilParams[] = {
+    // Stencil enable, depth disable
+    {NV097_SET_STENCIL_OP_V_ZERO, "ZERO", true, false, 0xFF, 0},
+    {NV097_SET_STENCIL_OP_V_REPLACE, "REPLACE", true, false, 0x00, 1},
+    // Stencil disable, depth enable
+    {NV097_SET_STENCIL_OP_V_ZERO, "ZERO", false, true, 0xFF, 0},
+    {NV097_SET_STENCIL_OP_V_REPLACE, "REPLACE", false, true, 0x00, 1},
+    // Stencil enable, depth enable
+    {NV097_SET_STENCIL_OP_V_ZERO, "ZERO", true, true, 0xFF, 0},
+    {NV097_SET_STENCIL_OP_V_REPLACE, "REPLACE", true, true, 0x00, 1},
+    // Stencil disable, depth disable
+    {NV097_SET_STENCIL_OP_V_ZERO, "ZERO", false, false, 0xFF, 0},
+    {NV097_SET_STENCIL_OP_V_REPLACE, "REPLACE", false, false, 0x00, 1}
+};
+
+StencilTests::StencilTests(TestHost &host, std::string output_dir)
+    : TestSuite(host, std::move(output_dir), "Stencil") {
+  for (auto param : kStencilParams) {
+      AddTestEntry(param);
+  }
+}
+
+void StencilTests::Initialize() {
+  TestSuite::Initialize();
+  SetDefaultTextureFormat();
+
+  auto shader = std::make_shared<PrecalculatedVertexShader>();
+  host_.SetVertexShaderProgram(shader);
+}
+
+void StencilTests::Test(const StencilParams &params) {
+  int quadSize = 200;
+
+  host_.SetupControl0(true);
+  host_.SetSurfaceFormat(host_.GetColorBufferFormat(),
+                         static_cast<TestHost::SurfaceZetaFormat>(NV097_SET_SURFACE_FORMAT_ZETA_Z24S8),
+                         host_.GetFramebufferWidth(), host_.GetFramebufferHeight());
+  host_.PrepareDraw(0xFF000000, 0x0000FFFF, params.stencil_clear_value);
+
+  // Disable color/zeta limit errors
+  auto crash_register = reinterpret_cast<uint32_t *>(PGRAPH_REGISTER_BASE + 0x880);
+  auto crash_register_pre_test = *crash_register;
+  *crash_register = crash_register_pre_test & (~0x800);
+  
+  // Enable color, disable depth/stencil, set depth/stencil test params
+  {
+    auto p = pb_begin();
+    p = pb_push1(p, NV097_SET_COLOR_MASK, 0x01010101);
+    p = pb_push1(p, NV097_SET_DEPTH_TEST_ENABLE, false);
+    p = pb_push1(p, NV097_SET_DEPTH_MASK, false);
+    p = pb_push1(p, NV097_SET_STENCIL_TEST_ENABLE, false);
+    p = pb_push1(p, NV097_SET_STENCIL_MASK, 0xFF);
+    p = pb_push1(p, NV097_SET_STENCIL_FUNC, 0x207);
+    p = pb_push1(p, NV097_SET_STENCIL_FUNC_REF, params.stencil_ref_value);
+    p = pb_push1(p, NV097_SET_STENCIL_FUNC_MASK, 0xFF);
+    p = pb_push1(p, NV097_SET_STENCIL_OP_FAIL, NV097_SET_STENCIL_OP_V_KEEP);
+    p = pb_push1(p, NV097_SET_STENCIL_OP_ZFAIL, NV097_SET_STENCIL_OP_V_KEEP);
+    p = pb_push1(p, NV097_SET_STENCIL_OP_ZPASS, params.stencil_op_zpass);
+    pb_end(p);
+  }
+
+  // Draw a red quad in the center of the screen
+  this->CreateGeometry(quadSize, 1, 0, 0);
+  host_.DrawArrays();
+
+  // Disable all masks except stencil, setup stencil test
+  {
+    auto p = pb_begin();
+    p = pb_push1(p, NV097_SET_COLOR_MASK, 0);
+    p = pb_push1(p, NV097_SET_STENCIL_TEST_ENABLE, params.stencil_test_enabled);
+    p = pb_push1(p, NV097_SET_DEPTH_MASK, false);
+    p = pb_push1(p, NV097_SET_DEPTH_TEST_ENABLE, params.depth_test_enabled);
+    p = pb_push1(p, NV097_SET_DEPTH_FUNC, NV097_SET_DEPTH_FUNC_V_ALWAYS);
+    pb_end(p);
+  }
+
+  // Draw a smaller quad to the zeta buffer
+  this->CreateGeometry(quadSize / 2.0f, 0, 0, 1);
+  host_.DrawArrays();
+
+  // Reenable masks, stencil test
+  {
+    auto p = pb_begin();
+    p = pb_push1(p, NV097_SET_COLOR_MASK, 0x01010101);
+    p = pb_push1(p, NV097_SET_DEPTH_TEST_ENABLE, false);
+    p = pb_push1(p, NV097_SET_DEPTH_MASK, false);
+    p = pb_push1(p, NV097_SET_STENCIL_TEST_ENABLE, true);
+    p = pb_push1(p, NV097_SET_STENCIL_FUNC, 0x202);
+    p = pb_push1(p, NV097_SET_STENCIL_OP_ZPASS, NV097_SET_STENCIL_OP_V_KEEP);
+    pb_end(p);
+  }
+
+  // Draw the first quad again, with a different color
+  this->CreateGeometry(quadSize, 0, 1, 0);
+  host_.DrawArrays();
+
+  pb_print("Stencil Op: %s\n", params.stencil_op_zpass_str);
+  pb_print("Stencil test: %s\n", params.stencil_test_enabled ? "Enabled" : "Disabled");
+  pb_print("Depth test: %s\n", params.depth_test_enabled ? "Enabled" : "Disabled");
+  pb_draw_text_screen();
+
+  std::string name = MakeTestName(params);
+  std::string z_name = name + "_ZB";
+  host_.FinishDraw(allow_saving_, output_dir_, name, z_name);
+
+  // Restore pgraph register 0x880
+  *crash_register = crash_register_pre_test;
+}
+
+void StencilTests::CreateGeometry(const float sideLength, const float r, const float g, const float b) {
+  auto fb_width = host_.GetFramebufferWidthF();
+  auto fb_height = host_.GetFramebufferHeightF();
+
+  float centerX = floorf(fb_width / 2.0f);
+  float centerY = floorf(fb_height / 2.0f);
+  float halfLength = floorf(sideLength / 2.0f);
+
+  uint32_t num_quads = 1;
+  std::shared_ptr<VertexBuffer> buffer = host_.AllocateVertexBuffer(6 * num_quads);
+
+  uint32_t idx = 0;
+
+  Color ul{};
+  Color ll{};
+  Color lr{};
+  Color ur{};
+
+  {
+    float z = 0.0f;
+
+    ul.SetRGB(r, g, b);
+    ll.SetRGB(r, g, b);
+    ur.SetRGB(r, g, b);
+    lr.SetRGB(r, g, b);
+
+    buffer->DefineBiTri(idx++, centerX - halfLength, centerY - halfLength, centerX + halfLength, centerY + halfLength, z, z, z, z, ul, ll, lr, ur);
+  }
+}
+
+std::string StencilTests::MakeTestName(const StencilParams &params) {
+  char buf[128] = {0};
+  snprintf(buf, 127, "Stencil_%s%s%s", 
+    params.stencil_op_zpass_str,
+    params.stencil_test_enabled ? "_ST" : "",
+    params.depth_test_enabled ? "_DT" : "");
+  return buf;
+}
+
+void StencilTests::AddTestEntry(const StencilTests::StencilParams &format) {
+  std::string name = MakeTestName(format);
+
+  auto test = [this, format]() {
+    this->Test(format);
+  };
+
+  tests_[name] = test;
+}

--- a/src/tests/stencil_tests.h
+++ b/src/tests/stencil_tests.h
@@ -1,0 +1,36 @@
+#ifndef NXDK_PGRAPH_TESTS_STENCIL_TESTS_H
+#define NXDK_PGRAPH_TESTS_STENCIL_TESTS_H
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "test_suite.h"
+
+class TestHost;
+
+class StencilTests : public TestSuite {
+ public:
+  struct StencilParams {
+    uint32_t stencil_op_zpass;
+    const char *stencil_op_zpass_str;
+    bool stencil_test_enabled;
+    bool depth_test_enabled;
+    uint32_t stencil_clear_value;
+    uint32_t stencil_ref_value;
+  };
+
+ public:
+  StencilTests(TestHost &host, std::string output_dir);
+
+  void Initialize() override;
+
+ private:
+  void CreateGeometry(const float sideLength, const float r, const float g, const float b);
+  void Test(const StencilParams &params);
+
+  void AddTestEntry(const StencilParams &params);
+  static std::string MakeTestName(const StencilParams &params);
+};
+
+#endif  // NXDK_PGRAPH_TESTS_STENCIL_TESTS_H


### PR DESCRIPTION
Sample with stencil test disabled
![Stencil_REPLACE](https://user-images.githubusercontent.com/25046221/170889398-76b78f9b-6ac3-4730-b557-8ee9a3dad5ed.png)
Sample with stencil test enabled
![Stencil_REPLACE_ST](https://user-images.githubusercontent.com/25046221/170889401-4412fec6-850d-4c6a-a798-270e175138d1.png)

Depth test enable/disable has no effect on HW, included for completeness.
