### PR TITLE
Adds test for xemu 950 - image blit after 3D draw to destination.

### DIFF
--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -172,12 +172,14 @@ void MenuItem::CursorRight(bool is_repeat) {
 }
 
 void MenuItem::CursorUpAndActivate() {
+  active_submenu->Deactivate();
   active_submenu = nullptr;
   CursorUp(false);
   Activate();
 }
 
 void MenuItem::CursorDownAndActivate() {
+  active_submenu->Deactivate();
   active_submenu = nullptr;
   CursorDown(false);
   Activate();
@@ -211,6 +213,9 @@ void MenuItemTest::OnEnter() {
   pb_print("Running %s", name.c_str());
   Swap();
 
+  if (has_run_once_) {
+    suite->Deinitialize();
+  }
   suite->Initialize();
   suite->SetSavingAllowed(true);
   has_run_once_ = false;
@@ -218,6 +223,7 @@ void MenuItemTest::OnEnter() {
 
 bool MenuItemTest::Deactivate() {
   suite->Deinitialize();
+  has_run_once_ = false;
   return MenuItem::Deactivate();
 }
 

--- a/src/test_host.h
+++ b/src/test_host.h
@@ -776,6 +776,14 @@ class TestHost {
   void DrawCheckerboardUnproject(uint32_t first_color = 0xFF00FFFF, uint32_t second_color = 0xFF000000,
                                  uint32_t checker_size = 8);
 
+  //! Sets up rendering to write to a non-framebuffer address.
+  void RenderToSurfaceStart(void *surface_address, SurfaceColorFormat color_format, uint32_t width, uint32_t height,
+                            bool swizzle = false, uint32_t clip_x = 0, uint32_t clip_y = 0, uint32_t clip_width = 0,
+                            uint32_t clip_height = 0, AntiAliasingSetting aa = AA_CENTER_1);
+
+  //! Restores rendering to the backbuffer.
+  void RenderToSurfaceEnd();
+
  private:
   //! Update matrices when the depth buffer format changes.
   void HandleDepthBufferFormatChange();
@@ -847,6 +855,9 @@ class TestHost {
       kNoStrideOverride, kNoStrideOverride, kNoStrideOverride, kNoStrideOverride, kNoStrideOverride, kNoStrideOverride,
       kNoStrideOverride, kNoStrideOverride, kNoStrideOverride, kNoStrideOverride, kNoStrideOverride, kNoStrideOverride,
       kNoStrideOverride, kNoStrideOverride, kNoStrideOverride, kNoStrideOverride};
+
+  //! Used to restore the color format after rendering to a non-framebuffer surface.
+  SurfaceColorFormat framebuffer_surface_color_format_{SCF_A8R8G8B8};
 };
 
 #endif  // NXDK_PGRAPH_TESTS_TEST_HOST_H

--- a/src/tests/image_blit_tests.h
+++ b/src/tests/image_blit_tests.h
@@ -31,6 +31,8 @@ class ImageBlitTests : public TestSuite {
 
   static std::string MakeTestName(const BlitTest& test);
 
+  void TestDirtyOverlappedDestinationSurface();
+
   uint32_t image_pitch_{0};
   uint32_t image_height_{0};
   uint8_t* source_image_{nullptr};

--- a/src/tests/texture_cubemap_tests.cpp
+++ b/src/tests/texture_cubemap_tests.cpp
@@ -117,7 +117,7 @@ void TextureCubemapTests::Initialize() {
     stage.SetTextureDimensions(normal_map->w, normal_map->h);
     host_.SetTextureFormat(GetTextureFormatInfo(NV097_SET_TEXTURE_FORMAT_COLOR_SZ_A8B8G8R8), 0);
     host_.SetTexture(normal_map);
-    SDL_free(normal_map);
+    SDL_FreeSurface(normal_map);
   }
 
   // Load the cube map into stage3


### PR DESCRIPTION
Bonus - fixes memory leak when navigating between/restarting tests w/ a deactivate handler.