### PR TITLE
Add DegenerateBeginEndTests to test drawing without END

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -3,11 +3,6 @@
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/cmake-build-debug/_deps/nxdkftplib-src" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/cmake-build-dump-config-file/_deps/nxdkftplib-src" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/cmake-build-forcedebug/_deps/nxdkftplib-src" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/cmake-build-host-debug---dump-mode-coverage/_deps/xboxmath_fetched-src" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/cmake-build-host-debug---dump-mode/_deps/xboxmath_fetched-src" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/cmake-build-host-debug-coverage/_deps/xboxmath_fetched-src" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/cmake-build-host-debug/_deps/xboxmath_fetched-src" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/cmake-build-release/_deps/nxdkftplib-src" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/third_party/fpng" vcs="Git" />

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,6 +220,8 @@ add_executable(
         tests/combiner_tests.h
         tests/context_switch_tests.cpp
         tests/context_switch_tests.h
+        tests/degenerate_begin_end_tests.cpp
+        tests/degenerate_begin_end_tests.h
         tests/depth_format_fixed_function_tests.cpp
         tests/depth_format_fixed_function_tests.h
         tests/depth_format_tests.cpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,7 @@
 #include "tests/color_zeta_overlap_tests.h"
 #include "tests/combiner_tests.h"
 #include "tests/context_switch_tests.h"
+#include "tests/degenerate_begin_end_tests.h"
 #include "tests/depth_format_fixed_function_tests.h"
 #include "tests/depth_format_tests.h"
 #include "tests/depth_function_tests.h"
@@ -406,6 +407,7 @@ static void RegisterSuites(TestHost& host, RuntimeConfig& runtime_config,
   REG_TEST(ColorZetaOverlapTests)
   REG_TEST(CombinerTests)
   REG_TEST(ContextSwitchTests)
+  REG_TEST(DegenerateBeginEndTests)
   REG_TEST(DepthFormatTests)
   REG_TEST(DepthFormatFixedFunctionTests)
   REG_TEST(DepthFunctionTests)

--- a/src/tests/degenerate_begin_end_tests.cpp
+++ b/src/tests/degenerate_begin_end_tests.cpp
@@ -1,0 +1,209 @@
+#include "degenerate_begin_end_tests.h"
+
+#include <pbkit/pbkit.h>
+
+#include "pbkit_ext.h"
+#include "shaders/passthrough_vertex_shader.h"
+#include "vertex_buffer.h"
+
+static const char kTestBeginWithoutEnd[] = "BeginWithoutEnd";
+
+/**
+ * Initializes the test suite and creates test cases.
+ *
+ * @tc BeginWithoutEnd
+ *   Renders a series of 3 triangles and one quad. The middle two triangles send NV097_SET_BEGIN_END with a triangle
+ *   primitive, but do not send NV097_SET_BEGIN_END with NV097_SET_BEGIN_END_OP_END when completed. The final quad is
+ *   treated as a triangle by the nv2a as the previous triangle primitive was never ended.
+ */
+DegenerateBeginEndTests::DegenerateBeginEndTests(TestHost &host, std::string output_dir, const Config &config)
+    : TestSuite(host, std::move(output_dir), "Degenerate begin end", config) {
+  tests_[kTestBeginWithoutEnd] = [this]() { TestBeginWithoutEnd(); };
+}
+
+void DegenerateBeginEndTests::Initialize() {
+  TestSuite::Initialize();
+  host_.SetXDKDefaultViewportAndFixedFunctionMatrices();
+
+  auto shader = std::make_shared<PassthroughVertexShader>();
+  host_.SetVertexShaderProgram(shader);
+}
+
+void DegenerateBeginEndTests::TestBeginWithoutEnd() {
+  host_.PrepareDraw(0xFE242424);
+
+  static constexpr float z = 1.f;
+  static constexpr float kHeader = 80.f;
+  static constexpr float width = 64.f;
+  const float x_offset = floorf(host_.GetFramebufferWidthF() / 5.f);
+
+  float cx = x_offset;
+  const float height = floorf((host_.GetFramebufferHeightF() - kHeader) / 10.f);
+  float cy = kHeader + height;
+  const float y_offset = height * 2.f;
+
+  auto draw_triangle = [this, &cx, &cy, x_offset, height]() {
+    const float left = floorf(cx - width / 2.f);
+    const float right = floorf(left + width);
+    const float top = floorf(cy - (height / 2.f));
+    const float bottom = floorf(cy + (height / 2.f));
+
+    Pushbuffer::PushF(NV097_SET_VERTEX3F, left, bottom, z);
+    Pushbuffer::PushF(NV097_SET_VERTEX3F, left, top, z);
+    Pushbuffer::PushF(NV097_SET_VERTEX3F, right, top, z);
+
+    cx += x_offset;
+  };
+
+  auto draw_quad = [this, &cx, &cy, x_offset, height]() {
+    const float left = floorf(cx - width / 2.f);
+    const float right = floorf(left + width);
+    const float top = floorf(cy - (height / 2.f));
+    const float bottom = floorf(cy + (height / 2.f));
+
+    Pushbuffer::PushF(NV097_SET_VERTEX3F, right, bottom, z);
+    Pushbuffer::PushF(NV097_SET_VERTEX3F, left, bottom, z);
+    Pushbuffer::PushF(NV097_SET_VERTEX3F, left, top, z);
+    Pushbuffer::PushF(NV097_SET_VERTEX3F, right, top, z);
+
+    cx += x_offset;
+  };
+
+  host_.SetDiffuse(1.0f, 0.0f, 0.0f);
+  Pushbuffer::Begin();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, TestHost::PRIMITIVE_TRIANGLES);
+  draw_triangle();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, NV097_SET_BEGIN_END_OP_END);
+  Pushbuffer::End();
+
+  // Draw the second triangle with a begin but no end.
+  host_.SetDiffuse(0.0f, 1.0f, 0.0f);
+  Pushbuffer::Begin();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, TestHost::PRIMITIVE_TRIANGLES);
+  draw_triangle();
+  Pushbuffer::End();
+
+  host_.SetDiffuse(0.0f, 0.0f, 1.0f);
+  Pushbuffer::Begin();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, TestHost::PRIMITIVE_TRIANGLES);
+  draw_triangle();
+  Pushbuffer::End();
+
+  host_.SetDiffuse(0.75f, 0.75f, 0.75f);
+  Pushbuffer::Begin();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, TestHost::PRIMITIVE_QUADS);
+  draw_quad();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, NV097_SET_BEGIN_END_OP_END);
+  Pushbuffer::End();
+
+  cx = x_offset;
+  cy += y_offset;
+  host_.SetDiffuse(1.0f, 0.0f, 0.0f);
+  Pushbuffer::Begin();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, TestHost::PRIMITIVE_QUADS);
+  draw_quad();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, NV097_SET_BEGIN_END_OP_END);
+  Pushbuffer::End();
+
+  host_.SetDiffuse(0.0f, 1.0f, 0.0f);
+  Pushbuffer::Begin();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, TestHost::PRIMITIVE_QUADS);
+  draw_quad();
+  Pushbuffer::End();
+
+  host_.SetDiffuse(0.0f, 0.0f, 1.0f);
+  Pushbuffer::Begin();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, TestHost::PRIMITIVE_TRIANGLES);
+  draw_triangle();
+  Pushbuffer::End();
+
+  host_.SetDiffuse(0.75f, 0.75f, 0.75f);
+  Pushbuffer::Begin();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, TestHost::PRIMITIVE_TRIANGLES);
+  draw_triangle();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, NV097_SET_BEGIN_END_OP_END);
+  Pushbuffer::End();
+
+  cx = x_offset;
+  cy += y_offset;
+  host_.SetDiffuse(1.0f, 0.0f, 0.0f);
+  Pushbuffer::Begin();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, TestHost::PRIMITIVE_QUADS);
+  draw_quad();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, NV097_SET_BEGIN_END_OP_END);
+  Pushbuffer::End();
+
+  host_.SetDiffuse(0.0f, 1.0f, 0.0f);
+  Pushbuffer::Begin();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, TestHost::PRIMITIVE_QUADS);
+  draw_quad();
+  Pushbuffer::End();
+
+  host_.SetDiffuse(0.0f, 0.0f, 1.0f);
+  Pushbuffer::Begin();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, TestHost::PRIMITIVE_TRIANGLES);
+  draw_triangle();
+  Pushbuffer::End();
+
+  host_.SetDiffuse(0.75f, 0.75f, 0.75f);
+  Pushbuffer::Begin();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, TestHost::PRIMITIVE_QUADS);
+  draw_quad();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, NV097_SET_BEGIN_END_OP_END);
+  Pushbuffer::End();
+
+  cx = x_offset;
+  cy += y_offset;
+  host_.SetDiffuse(1.0f, 0.0f, 0.0f);
+  Pushbuffer::Begin();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, TestHost::PRIMITIVE_POLYGON);
+  draw_quad();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, NV097_SET_BEGIN_END_OP_END);
+  Pushbuffer::End();
+
+  host_.SetDiffuse(0.0f, 1.0f, 0.0f);
+  Pushbuffer::Begin();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, TestHost::PRIMITIVE_POLYGON);
+  draw_quad();
+  Pushbuffer::End();
+
+  host_.SetDiffuse(0.0f, 0.0f, 1.0f);
+  Pushbuffer::Begin();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, TestHost::PRIMITIVE_TRIANGLES);
+  draw_triangle();
+  Pushbuffer::End();
+
+  host_.SetDiffuse(0.75f, 0.75f, 0.75f);
+  Pushbuffer::Begin();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, TestHost::PRIMITIVE_QUADS);
+  draw_quad();
+  Pushbuffer::Push(NV097_SET_BEGIN_END, NV097_SET_BEGIN_END_OP_END);
+  Pushbuffer::End();
+
+  pb_print("%s\n", kTestBeginWithoutEnd);
+  pb_print("Center primitives omit NV097_SET_BEGIN_END_OP_END\n");
+  pb_print("Tri: LB, LT, RT              Quad: RB, LB, LT, RT\n");
+  pb_printat(5, 9, "Tri");
+  pb_printat(5, 22, "Tri");
+  pb_printat(5, 35, "Tri");
+  pb_printat(5, 48, "Quad");
+
+  pb_printat(8, 9, "Quad");
+  pb_printat(8, 22, "Quad");
+  pb_printat(8, 35, "Tri");
+  pb_printat(8, 48, "Tri");
+
+  pb_printat(11, 9, "Quad");
+  pb_printat(11, 22, "Quad");
+  pb_printat(11, 35, "Tri");
+  pb_printat(11, 48, "Quad");
+
+  pb_printat(15, 9, "Poly 4");
+  pb_printat(15, 22, "Poly 4");
+  pb_printat(15, 35, "Tri");
+  pb_printat(15, 48, "Quad");
+
+  pb_draw_text_screen();
+
+  host_.FinishDraw(allow_saving_, output_dir_, suite_name_, kTestBeginWithoutEnd);
+}

--- a/src/tests/degenerate_begin_end_tests.h
+++ b/src/tests/degenerate_begin_end_tests.h
@@ -1,0 +1,23 @@
+#ifndef NXDK_PGRAPH_TESTS_DEGENERATE_BEGIN_END_TESTS_H
+#define NXDK_PGRAPH_TESTS_DEGENERATE_BEGIN_END_TESTS_H
+
+#include <memory>
+#include <vector>
+
+#include "test_host.h"
+#include "test_suite.h"
+
+/**
+ * Tests atypical situations involving NV097_SET_BEGIN_END.
+ */
+class DegenerateBeginEndTests : public TestSuite {
+ public:
+  DegenerateBeginEndTests(TestHost& host, std::string output_dir, const Config& config);
+
+  void Initialize() override;
+
+ private:
+  void TestBeginWithoutEnd();
+};
+
+#endif  // NXDK_PGRAPH_TESTS_DEGENERATE_BEGIN_END_TESTS_H


### PR DESCRIPTION
This change introduces a new test suite, `DegenerateBeginEndTests`, with a single test case `TestBeginWithoutEnd`.

This test is designed to verify the behavior of the graphics pipeline when `NV097_SET_BEGIN_END` is called multiple times with a `PRIMITIVE_TRIANGLES` primitive, but without an `NV097_SET_BEGIN_END_OP_END` command in between the draws.

The test draws four triangles:
- The first and last triangles are drawn with a traditional BEGIN/END pair.
- The second and third triangles are drawn with a BEGIN command but no corresponding END command.

co-authored-by: erik.abair@gmail.com