### PR TITLE
Add blit render blit test

### DIFF
--- a/src/tests/image_blit_tests.h
+++ b/src/tests/image_blit_tests.h
@@ -38,6 +38,10 @@ class ImageBlitTests : public TestSuite {
 
   void TestDirtyOverlappedDestinationSurface();
 
+  //! Reproduces an issue where blitting, rendering, then blitting again causes corruption.
+  //! https://github.com/xemu-project/xemu/issues/2199
+  void BlitRenderBlit();
+
   uint32_t image_pitch_{0};
   uint32_t image_height_{0};
   uint8_t* source_image_{nullptr};

--- a/src/tests/image_blit_tests.h
+++ b/src/tests/image_blit_tests.h
@@ -40,7 +40,7 @@ class ImageBlitTests : public TestSuite {
 
   //! Reproduces an issue where blitting, rendering, then blitting again causes corruption.
   //! https://github.com/xemu-project/xemu/issues/2199
-  void BlitRenderBlit();
+  void TestBlitRenderBlit();
 
   uint32_t image_pitch_{0};
   uint32_t image_height_{0};
@@ -51,6 +51,7 @@ class ImageBlitTests : public TestSuite {
   struct s_CtxDma clip_rect_ctx_{};
   struct s_CtxDma beta_ctx_{};
   struct s_CtxDma beta4_ctx_{};
+  struct s_CtxDma render_target_dma_ctx_{};
 };
 
 #endif  // NXDK_PGRAPH_TESTS_IMAGE_BLIT_TESTS_H


### PR DESCRIPTION
This was an attempt to reproduce xemu#2199 but ended up discovering a novel issue instead.

xemu#2199 seems to be covered by the DirtyOverlappedDestSurf test, as a hackaround fix for that test also fixes 2199.