### PR TITLE
Adds tests that set fog to RCP of arbitrary values.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,6 +93,7 @@ generate_nv2a_vshinc_files(
         shaders/passthrough_no_point_size.vsh
         shaders/projection_vertex_shader_no_lighting.vsh
         shaders/projection_vertex_shader_no_lighting_explicit_fog.vsh
+        shaders/projection_vertex_shader_no_lighting_rcp_fog.vsh
         shaders/weight_to_color.vsh
 )
 

--- a/src/shaders/projection_vertex_shader_no_lighting_rcp_fog.vsh
+++ b/src/shaders/projection_vertex_shader_no_lighting_rcp_fog.vsh
@@ -1,0 +1,33 @@
+; A vertex shader that performs transformation and passes through all other
+; vertex attributes apart from fog, which is taken from uniform 120
+
+#model_matrix matrix4 96
+#view_matrix matrix4 100
+#projection_matrix matrix4 104
+
+#fog_value vector 120
+
+; -- Transform the vertex. -----------------
+%matmul4x4 r0 iPos #model_matrix
+%matmul4x4 r1 r0 #view_matrix
+%matmul4x4 r0 r1 #projection_matrix
+
+; oPos.xyz = r0.xyz / r0.w
+rcp r1.x, r0.w
+mul oPos.xyz, r0, r1.x
+mov oPos.w, r0
+; ------------------------------------------
+
+
+mov oDiffuse, iDiffuse
+mov oSpecular, iSpecular
+mov oBackDiffuse, iBackDiffuse
+mov oBackSpecular, iBackSpecular
+
+rcp oFog, #fog_value
+
+mov oPts, iPts
+mov oTex0, iTex0
+mov oTex1, iTex1
+mov oTex2, iTex2
+mov oTex3, iTex3

--- a/src/tests/fog_exceptional_value_tests.h
+++ b/src/tests/fog_exceptional_value_tests.h
@@ -22,7 +22,7 @@ class FogExceptionalValueTests : public TestSuite {
   void Initialize() override;
 
  private:
-  void Test(const std::string& name, uint32_t fog_mode, uint32_t fog_gen_mode);
+  void Test(const std::string& name, uint32_t fog_mode, uint32_t fog_gen_mode, bool use_rcp);
 };
 
 #endif  // NXDK_PGRAPH_TESTS_FOG_EXCEPTIONAL_VALUE_TESTS_H


### PR DESCRIPTION
Intended to help diagnose
https://github.com/xemu-project/xemu/issues/2474
https://github.com/xemu-project/xemu/issues/2412
https://github.com/xemu-project/xemu/issues/2200
https://github.com/xemu-project/xemu/issues/632

and possibly other cases where xemu's demonstrated behavior differs from HW with an inf fog value emitted from the VSH because of a `RCP 0`.