### PR TITLE
Fixes point params tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,7 @@ generate_nv2a_vshinc_files(
         shaders/fog_vec4_z.vsh
         shaders/fog_vec4_zw.vsh
         shaders/passthrough.vsh
+        shaders/passthrough_diffuse_from_point_size_mul_const.vsh
         shaders/passthrough_just_position_and_color.vsh
         shaders/passthrough_mul_color_by_constant.vsh
         shaders/passthrough_no_point_size.vsh

--- a/src/shaders/passthrough_diffuse_from_point_size_mul_const.vsh
+++ b/src/shaders/passthrough_diffuse_from_point_size_mul_const.vsh
@@ -1,0 +1,17 @@
+; A vertex shader that passes through all parameters except diffuse with no
+; manipulation. Diffuse is set to iPts multiplied by the first uniform.
+
+#diffuse_multiplier vector 120
+
+
+mov oPos, iPos
+mul oDiffuse, iPts, #diffuse_multiplier
+mov oSpecular, iSpecular
+mov oFog, iFog
+mov oPts, iPts
+mov oBackDiffuse, iBackDiffuse
+mov oBackSpecular, iBackSpecular
+mov oTex0, iTex0
+mov oTex1, iTex1
+mov oTex2, iTex2
+mov oTex3, iTex3


### PR DESCRIPTION
VSH oPts is only considered when NV097_SET_POINT_PARAMS_ENABLE is true and iPts is not influenced by SET_POINT_SIZE. This fixes up several tests that require valid iPts values (switching to inline arrays) and adds tests demonstrating the behavior of SET_POINT_PARAMS and SET_POINT_SIZE.