### PR TITLE
Add CpuSurfaceUploadFilter test to ImageBlit suite to explicitly test linear filter pipeline

### DIFF
--- a/src/tests/image_blit_tests.cpp
+++ b/src/tests/image_blit_tests.cpp
@@ -33,6 +33,7 @@ static constexpr char kBlitRenderBlitTest[] = "BlitRenderBlit";
 static constexpr char kOverlapFIFOTest[] = "OverlapFIFO";
 #endif
 static constexpr char kBlitPastWidthTest[] = "BlitBeyondWidth";
+static constexpr char kXemuScaledSurfaceUploadFilterTest[] = "XemuScaledSurfaceUploadFilter";
 
 #define SOURCE_X 8
 #define SOURCE_Y 8
@@ -185,6 +186,13 @@ static std::string MakeTestName(uint32_t clip_x, uint32_t clip_y, uint32_t clip_
  * @tc Overlap_BR_Inside
  *   Tests the boundary condition of xemu's 2D blit overlap detection by performing a 1x1 pixel blit exactly inside the
  *   bottom-right corner of a 3D render surface.
+ *
+ * @tc XemuScaledSurfaceUploadFilter
+ *   Writes 1-pixel-wide alternating R/B vertical stripes to the framebuffer via CPU, then issues a GPU draw to
+ *   trigger xemu's internal surface upload (pgraph_vk_upload_surface_data). After GPU completion the framebuffer
+ *   is read back via CPU, which triggers xemu's download path. At scale > 1x the NEAREST+NEAREST round-trip
+ *   preserves exact R/B values, while any other filtering produces blended intermediate values that fail the
+ *   channel-purity check. At scale == 1x no upscale occurs and the test passes trivially.
  */
 ImageBlitTests::ImageBlitTests(TestHost& host, std::string output_dir, const Config& config)
     : TestSuite(host, std::move(output_dir), "Image blit", config) {
@@ -239,6 +247,7 @@ ImageBlitTests::ImageBlitTests(TestHost& host, std::string output_dir, const Con
   tests_[kDirtyOverlappedDestSurfaceTest] = [this]() { TestDirtyOverlappedDestinationSurface(); };
   tests_[kBlitRenderBlitTest] = [this]() { TestBlitRenderBlit(); };
   tests_[kBlitPastWidthTest] = [this]() { TestBlitPastWidth(kBlitPastWidthTest); };
+  tests_[kXemuScaledSurfaceUploadFilterTest] = [this]() { TestXemuScaledSurfaceUploadFilter(); };
 }
 
 void ImageBlitTests::Initialize() {
@@ -835,6 +844,79 @@ void ImageBlitTests::TestBlitRenderBlit() {
   pb_draw_text_screen();
 
   FinishDraw(kBlitRenderBlitTest);
+}
+
+void ImageBlitTests::TestXemuScaledSurfaceUploadFilter() {
+  static constexpr uint32_t kTestW = 128;
+  static constexpr uint32_t kTestH = 128;
+  static constexpr uint32_t kColorA = 0x00FF0000;  // red
+  static constexpr uint32_t kColorB = 0x000000FF;  // blue
+
+  host_.PrepareDraw(0xFF111111);
+
+  auto* fb = static_cast<uint32_t*>(pb_agp_access(pb_back_buffer()));
+  const uint32_t pitch_pixels = pb_back_buffer_pitch() / 4;
+  const uint32_t start_x = (host_.GetFramebufferWidth() - kTestW) / 2;
+  const uint32_t start_y = (host_.GetFramebufferHeight() - kTestH) / 2;
+
+  uint32_t row_offset = start_y * pitch_pixels + start_x;
+  for (uint32_t y = 0; y < kTestH; ++y, row_offset += pitch_pixels) {
+    for (uint32_t x = 0; x < kTestW; ++x) {
+      fb[row_offset + x] = (x % 2 == 0) ? kColorA : kColorB;
+    }
+  }
+
+  // Minimal GPU draw to trigger the surface upload and set draw_dirty.
+  // Placed in the bottom-right corner to avoid the test region.
+  host_.SetFinalCombiner0Just(TestHost::SRC_DIFFUSE);
+  host_.SetFinalCombiner1Just(TestHost::SRC_ZERO, true, true);
+  host_.Begin(TestHost::PRIMITIVE_QUADS);
+  host_.SetDiffuse(0.f, 0.f, 0.f, 0.f);
+  host_.SetScreenVertex(630.f, 460.f, 0.f);
+  host_.SetScreenVertex(634.f, 460.f, 0.f);
+  host_.SetScreenVertex(634.f, 464.f, 0.f);
+  host_.SetScreenVertex(630.f, 464.f, 0.f);
+  host_.End();
+
+  host_.PBKitBusyWait();
+
+  bool pass = true;
+  uint32_t fail_count = 0;
+  uint32_t first_actual = 0;
+  uint32_t first_expected = 0;
+  static constexpr uint32_t kMaxLoggedFailures = 16;
+
+  row_offset = start_y * pitch_pixels + start_x;
+  for (uint32_t y = 0; y < kTestH; ++y, row_offset += pitch_pixels) {
+    for (uint32_t x = 0; x < kTestW; ++x) {
+      const uint32_t actual = fb[row_offset + x];
+      const bool expect_red = (x % 2 == 0);
+      const uint32_t expected = (expect_red ? kColorA : kColorB) & 0xFFFFFF;
+      const bool pixel_pass = (actual & 0xFFFFFF) == expected;
+
+      if (!pixel_pass) {
+        if (fail_count < kMaxLoggedFailures) {
+          PrintMsg("FAIL [%u,%u]: expected %s, got 0x%06X\n", x, y, expect_red ? "RED" : "BLUE", actual & 0xFFFFFF);
+        }
+        if (fail_count == 0) {
+          first_actual = actual & 0xFFFFFF;
+          first_expected = expected;
+        }
+        pass = false;
+        ++fail_count;
+      }
+    }
+  }
+
+  pb_print("%s\n", kXemuScaledSurfaceUploadFilterTest);
+  pb_print("1px R/B stripes: CPU write -> GPU draw -> readback\n");
+  pb_print("Result: %s\n", pass ? "PASS" : "FAIL");
+  if (!pass) {
+    pb_print("%u failures, first: exp 0x%06X got 0x%06X\n", fail_count, first_expected, first_actual);
+  }
+  pb_draw_text_screen();
+
+  FinishDraw(kXemuScaledSurfaceUploadFilterTest);
 }
 
 static std::string OperationName(uint32_t operation) {

--- a/src/tests/image_blit_tests.h
+++ b/src/tests/image_blit_tests.h
@@ -52,6 +52,7 @@ class ImageBlitTests : public TestSuite {
   //! Reproduces an issue where blitting, rendering, then blitting again causes corruption.
   //! https://github.com/xemu-project/xemu/issues/2199
   void TestBlitRenderBlit();
+  void TestXemuScaledSurfaceUploadFilter();
 
   uint32_t image_pitch_{0};
   uint32_t image_width_{0};


### PR DESCRIPTION
Add CpuSurfaceUploadFilter test to ImageBlit suite

Tests the round-trip fidelity of CPU-written surface data through xemu's internal scale path.

Specifically this targets the bug which is fixed in [xemu-project/xemu#2874](https://github.com/xemu-project/xemu/pull/2874), where `pgraph_vk_upload_surface_data` used the linear filter instead of nearest causing blurred visuals when upscaling CPU-written surfaces to the internal GPU resolution.

The test writes 1-pixel-wide alternating red/blue vertical stripes directly to the framebuffer via CPU, then issues a minimal GPU draw to trigger the surface upload. Reading the framebuffer back via CPU then triggers the download path. With Vulkan as the renderer and 1x (no upscale) the round-trip should be pixel-exact.

This test will fail with current xemu 0.8.135 with the Vulkan renderer with an upscale >= 2x (but passes with the fixes mentioned above).

Resulting pass for PR branch mentioned earlier:
<img width="1280" height="960" alt="xemu-2026-05-24-18-37-44" src="https://github.com/user-attachments/assets/28a02276-e600-4aed-b247-3c4ed9a0e6b1" />

Current xemu 0.8.135:

<img width="1280" height="960" alt="xemu-2026-05-24-18-38-25" src="https://github.com/user-attachments/assets/034eef6e-4b04-4203-bdc7-1c3421b5da96" />

Just for posterity, I ran this on real hardware, too (it should pass), this is through a HDMI converter -> HDMI capture device so it's already upscaling a bit: 
<img width="3840" height="2160" alt="Screenshot 2026-05-24 19-10-33" src="https://github.com/user-attachments/assets/d54cbeaf-9726-4d0b-9353-37f592c06afd" />


Please let me know if you want any changes, I am really over my head with this already so I do want to emphasize that I actually know very little about this stuff, but I'm willing to learn.